### PR TITLE
Change name of fixture results

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ public async Task ExampleTest()
 }
 ```
 
-#### 2. Apply Mocks
-Use the builder pattern to add any required mocks to your fixture:
+#### 2. Add Mocks
+Add desired mocks:
 ```csharp
 [Fact]
 public async Task ExampleTest() 
@@ -65,8 +65,25 @@ public async Task ExampleTest()
 }
 ```
 
-#### 3. Build the Fixture & Write Assertions
-Build the fixture to run your test setup, then use convenient extension methods to write your assertions:
+#### 3. Execute Test
+Build the `FixtureBuilder` to run the Pulumi program in test mode, resulting in a `Fixture` object 
+that captures the simulated deployment state without performing any real infrastructure changes:
+```csharp
+[Fact]
+public async Task ExampleTest() 
+{
+    var fixtureBuilder = new FixtureBuilder()
+        .WithMockResource(new MockResourceBuilder<ResourceGroup>()
+            .WithOutput(x => x.Location, "swedencentral")
+            .Build()); 
+    
+    var fixture = await fixtureBuilder
+        .BuildAsync(async () => await CoreStack.DefineResourcesAsync()); // Your code that creates resources.
+}
+```
+
+#### 4. Extract information & Write Assertions
+Use convenient extension methods to extract information from the `Fixture` and write your assertions:
 ```csharp
 [Fact]
 public async Task ExampleTest() 
@@ -79,7 +96,7 @@ public async Task ExampleTest()
     var fixture = await fixtureBuilder
         .BuildAsync(async () => await CoreStack.DefineResourcesAsync()); // Your code that creates resources.
     
-    var resourceGroup = fixture.StackResources.Require<ResourceGroup>();
+    var resourceGroup = fixture.Resources.Require<ResourceGroup>();
     var location = await resourceGroup.Location.GetValueAsync();
     
     location.ShouldBe("swedencentral");

--- a/Source/Example.Tests.WithPulumock/CallTests.cs
+++ b/Source/Example.Tests.WithPulumock/CallTests.cs
@@ -59,7 +59,7 @@ public class CallTests : ICallTests
                 .Build(typeof(GetRoleDefinition)))
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
-        RoleAssignment roleAssignment = fixture.StackResources.Require<RoleAssignment>("microservice-ra-kvReader");
+        RoleAssignment roleAssignment = fixture.Resources.Require<RoleAssignment>("microservice-ra-kvReader");
 
         string roleDefinitionId = await roleAssignment.RoleDefinitionId.GetValueAsync();
         roleDefinitionId.ShouldBe(getRoleDefinitionId);

--- a/Source/Example.Tests.WithPulumock/CallTests.cs
+++ b/Source/Example.Tests.WithPulumock/CallTests.cs
@@ -19,7 +19,7 @@ public class CallTests : ICallTests
         Fixture fixture = await TestBase.GetBaseFixtureBuilder()
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
 
-        ImmutableList<EnrichedCall> getRoleDefinitionCalls = fixture.EnrichedStackCalls.GetMany(typeof(GetRoleDefinition));
+        ImmutableList<EnrichedCall> getRoleDefinitionCalls = fixture.EnrichedCalls.GetMany(typeof(GetRoleDefinition));
         ImmutableList<string> roleDefinitionIds = getRoleDefinitionCalls.RequireManyInputValues<GetRoleDefinitionInvokeArgs, string>(x => 
             x.RoleDefinitionId);
         
@@ -38,7 +38,7 @@ public class CallTests : ICallTests
                 .Build(typeof(GetRoleDefinition)))
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
-        ImmutableList<EnrichedCall> getRoleDefinitionCallsWithId = fixture.EnrichedStackCalls.GetManyByValue<GetRoleDefinitionInvokeArgs, string>(
+        ImmutableList<EnrichedCall> getRoleDefinitionCallsWithId = fixture.EnrichedCalls.GetManyByValue<GetRoleDefinitionInvokeArgs, string>(
             typeof(GetRoleDefinition),
             x => x.RoleDefinitionId,
             getRoleDefinitionId);

--- a/Source/Example.Tests.WithPulumock/ComponentResourceTests.cs
+++ b/Source/Example.Tests.WithPulumock/ComponentResourceTests.cs
@@ -124,7 +124,7 @@ public class ComponentResourceTests : IComponentResourceTests
                 };
             });
 
-        Vault keyVault = await fixture.StackOutputs.RequireValueAsync<Vault>("keyVault");
+        Vault keyVault = await fixture.RegisteredOutputs.RequireValueAsync<Vault>("keyVault");
         
         keyVault.GetResourceName().ShouldBe("microservice-kvws-kv");
     }

--- a/Source/Example.Tests.WithPulumock/ComponentResourceTests.cs
+++ b/Source/Example.Tests.WithPulumock/ComponentResourceTests.cs
@@ -36,9 +36,9 @@ public class ComponentResourceTests : IComponentResourceTests
             });
 
         KeyVaultWithSecretsComponentResource componentResource =
-            fixture.StackResources.Require<KeyVaultWithSecretsComponentResource>();
-        Vault keyVault = fixture.StackResources.Require<Vault>();
-        Secret secret = fixture.StackResources.Require<Secret>();
+            fixture.Resources.Require<KeyVaultWithSecretsComponentResource>();
+        Vault keyVault = fixture.Resources.Require<Vault>();
+        Secret secret = fixture.Resources.Require<Secret>();
 
         SecretPropertiesResponse secretProperties = await secret.Properties.GetValueAsync();
         
@@ -67,7 +67,7 @@ public class ComponentResourceTests : IComponentResourceTests
                 };
             });
 
-        Secret? secret = fixture.StackResources.Get<Secret>();
+        Secret? secret = fixture.Resources.Get<Secret>();
         
         secret.ShouldBeNull();
     }
@@ -96,9 +96,9 @@ public class ComponentResourceTests : IComponentResourceTests
             });
 
         KeyVaultWithSecretsComponentResource componentResource =
-            fixture.StackResources.Require<KeyVaultWithSecretsComponentResource>();
-        Vault keyVault = fixture.StackResources.Require<Vault>();
-        Secret secret = fixture.StackResources.Require<Secret>();
+            fixture.Resources.Require<KeyVaultWithSecretsComponentResource>();
+        Vault keyVault = fixture.Resources.Require<Vault>();
+        Secret secret = fixture.Resources.Require<Secret>();
         
         keyVault.IsChildOf(componentResource).ShouldBeTrue();
         secret.IsChildOf(componentResource).ShouldBeTrue();

--- a/Source/Example.Tests.WithPulumock/ConfigurationTests.cs
+++ b/Source/Example.Tests.WithPulumock/ConfigurationTests.cs
@@ -24,7 +24,7 @@ public class ConfigurationTests : IConfigurationTests
             .WithMockStackConfiguration(PulumiConfigurationNamespace.AzureNative, "tenantId", TenantId)
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
-        EnrichedResource enrichedResource = fixture.EnrichedStackResources.Require("microservice-kvws-kv");
+        EnrichedResource enrichedResource = fixture.EnrichedResources.Require("microservice-kvws-kv");
         string vaultTenantId = enrichedResource.RequireInputValue<VaultArgs, VaultPropertiesArgs, string>(
             x => x.Properties, 
             y => y.TenantId);
@@ -57,7 +57,7 @@ public class ConfigurationTests : IConfigurationTests
             .WithMockStackConfiguration(PulumiConfigurationNamespace.AzureNative, "tenantId", tenantId)
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
-        EnrichedResource enrichedResource = fixture.EnrichedStackResources.Require("microservice-kvws-kv");
+        EnrichedResource enrichedResource = fixture.EnrichedResources.Require("microservice-kvws-kv");
         string vaultTenantId = enrichedResource.RequireInputValue<VaultArgs, VaultPropertiesArgs, string>(
             x => x.Properties, 
             y => y.TenantId);

--- a/Source/Example.Tests.WithPulumock/ConfigurationTests.cs
+++ b/Source/Example.Tests.WithPulumock/ConfigurationTests.cs
@@ -41,7 +41,7 @@ public class ConfigurationTests : IConfigurationTests
             .WithMockStackConfiguration(PulumiConfigurationNamespace.Default, "databaseConnectionString", databaseConnectionStringSecret)
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
-        Secret secret = fixture.StackResources.Require<Secret>("microservice-kvws-secret-Database--ConnectionString");
+        Secret secret = fixture.Resources.Require<Secret>("microservice-kvws-secret-Database--ConnectionString");
 
         SecretPropertiesResponse secretProperties = await secret.Properties.GetValueAsync();
         secretProperties.Value.ShouldBe(databaseConnectionStringSecret);

--- a/Source/Example.Tests.WithPulumock/ResourceTests.cs
+++ b/Source/Example.Tests.WithPulumock/ResourceTests.cs
@@ -21,7 +21,7 @@ public class ResourceTests : IResourceTests
         Fixture fixture = await TestBase.GetBaseFixtureBuilder()
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
-        EnrichedResource enrichedResourceGroup = fixture.EnrichedStackResources.Require("microservice-rg");
+        EnrichedResource enrichedResourceGroup = fixture.EnrichedResources.Require("microservice-rg");
         string resourceGroupName = enrichedResourceGroup.RequireInputValue<ResourceGroupArgs, string>(x => x.ResourceGroupName);
         
         resourceGroupName.ShouldBe("microservice-rg");
@@ -52,7 +52,7 @@ public class ResourceTests : IResourceTests
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
         ResourceGroup resourceGroup = fixture.Resources.Require<ResourceGroup>("microservice-rg");
-        EnrichedResource enrichedResourceGroup = fixture.EnrichedStackResources.Require("microservice-rg");
+        EnrichedResource enrichedResourceGroup = fixture.EnrichedResources.Require("microservice-rg");
 
         string locationFromOutput = await resourceGroup.Location.GetValueAsync();
         string locationFromInput = enrichedResourceGroup.RequireInputValue<ResourceGroupArgs, string>(x => x.Location);
@@ -70,7 +70,7 @@ public class ResourceTests : IResourceTests
         ResourceGroup resourceGroup = fixture.Resources.Require<ResourceGroup>("microservice-rg");
         string resourceGroupName = await resourceGroup.Name.GetValueAsync();
         
-        EnrichedResource keyVault = fixture.EnrichedStackResources.Require("microservice-kvws-kv");
+        EnrichedResource keyVault = fixture.EnrichedResources.Require("microservice-kvws-kv");
         string keyVaultResourceGroupName = keyVault.RequireInputValue<VaultArgs, string>(x => x.ResourceGroupName);
 
         keyVaultResourceGroupName.ShouldBe(resourceGroupName);

--- a/Source/Example.Tests.WithPulumock/ResourceTests.cs
+++ b/Source/Example.Tests.WithPulumock/ResourceTests.cs
@@ -37,7 +37,7 @@ public class ResourceTests : IResourceTests
                 .Build())
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
-        ResourceGroup resourceGroup = fixture.StackResources.Require<ResourceGroup>("microservice-rg");
+        ResourceGroup resourceGroup = fixture.Resources.Require<ResourceGroup>("microservice-rg");
         string azureApiVersion = await resourceGroup.AzureApiVersion.GetValueAsync();
         
         azureApiVersion.ShouldBe(expectedAzureApiVersion);
@@ -51,7 +51,7 @@ public class ResourceTests : IResourceTests
             .WithMockStackConfiguration(PulumiConfigurationNamespace.AzureNative, "location", location)
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
-        ResourceGroup resourceGroup = fixture.StackResources.Require<ResourceGroup>("microservice-rg");
+        ResourceGroup resourceGroup = fixture.Resources.Require<ResourceGroup>("microservice-rg");
         EnrichedResource enrichedResourceGroup = fixture.EnrichedStackResources.Require("microservice-rg");
 
         string locationFromOutput = await resourceGroup.Location.GetValueAsync();
@@ -67,7 +67,7 @@ public class ResourceTests : IResourceTests
         Fixture fixture = await TestBase.GetBaseFixtureBuilder()
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
         
-        ResourceGroup resourceGroup = fixture.StackResources.Require<ResourceGroup>("microservice-rg");
+        ResourceGroup resourceGroup = fixture.Resources.Require<ResourceGroup>("microservice-rg");
         string resourceGroupName = await resourceGroup.Name.GetValueAsync();
         
         EnrichedResource keyVault = fixture.EnrichedStackResources.Require("microservice-kvws-kv");
@@ -84,7 +84,7 @@ public class ResourceTests : IResourceTests
             .WithMockStackConfiguration(PulumiConfigurationNamespace.AzureNative, "location", location)
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
 
-        ImmutableArray<ResourceGroup> resourceGroups = fixture.StackResources.GetMany<ResourceGroup>();
+        ImmutableArray<ResourceGroup> resourceGroups = fixture.Resources.GetMany<ResourceGroup>();
         string[] locations = await resourceGroups.GetManyValuesAsync(x => x.Location);
         
         resourceGroups.ShouldAllBe(x => !string.Equals(x.GetResourceName(), "forbidden-resource-name", StringComparison.Ordinal));

--- a/Source/Example.Tests.WithPulumock/StackOutputTests.cs
+++ b/Source/Example.Tests.WithPulumock/StackOutputTests.cs
@@ -29,7 +29,7 @@ public class StackOutputTests : IStackOutputTests
         Vault keyVault = fixture.Resources.Require<Vault>("microservice-kvws-kv");
         VaultPropertiesResponse keyVaultProperties = await keyVault.Properties.GetValueAsync();
         
-        string keyVaultUriStackOutput = await fixture.StackOutputs.RequireValueAsync<string>("keyVaultUri");
+        string keyVaultUriStackOutput = await fixture.RegisteredOutputs.RequireValueAsync<string>("keyVaultUri");
 
         keyVaultUriStackOutput.ShouldBe(keyVaultProperties.VaultUri);
         keyVaultUriStackOutput.ShouldBe(mockedVaultUri);

--- a/Source/Example.Tests.WithPulumock/StackOutputTests.cs
+++ b/Source/Example.Tests.WithPulumock/StackOutputTests.cs
@@ -26,7 +26,7 @@ public class StackOutputTests : IStackOutputTests
                 .Build())
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync());
 
-        Vault keyVault = fixture.StackResources.Require<Vault>("microservice-kvws-kv");
+        Vault keyVault = fixture.Resources.Require<Vault>("microservice-kvws-kv");
         VaultPropertiesResponse keyVaultProperties = await keyVault.Properties.GetValueAsync();
         
         string keyVaultUriStackOutput = await fixture.StackOutputs.RequireValueAsync<string>("keyVaultUri");

--- a/Source/Example.Tests.WithPulumock/StackReferenceTests.cs
+++ b/Source/Example.Tests.WithPulumock/StackReferenceTests.cs
@@ -27,7 +27,7 @@ public class StackReferenceTests : IStackReferenceTests
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync(),
                 new TestOptions { IsPreview = false, StackName = stackName });
 
-        RoleAssignment roleAssignment = fixture.StackResources.Require<RoleAssignment>("microservice-ra-kvReader");
+        RoleAssignment roleAssignment = fixture.Resources.Require<RoleAssignment>("microservice-ra-kvReader");
         string principalId = await roleAssignment.PrincipalId.GetValueAsync();
         
         principalId.ShouldBe(stackReferenceOutputValue);
@@ -45,7 +45,7 @@ public class StackReferenceTests : IStackReferenceTests
             .BuildAsync(async () => await CoreStack.DefineResourcesAsync(),
                 new TestOptions { IsPreview = false, StackName = TestBase.DevStackName });
 
-        RoleAssignment roleAssignment = fixture.StackResources.Require<RoleAssignment>("microservice-ra-kvReader");
+        RoleAssignment roleAssignment = fixture.Resources.Require<RoleAssignment>("microservice-ra-kvReader");
         string principalId = await roleAssignment.PrincipalId.GetValueAsync();
         
         principalId.ShouldBe(stackReferenceOutputValue);

--- a/Source/Pulumock/Extensions/RegisteredOutputsExtensions.cs
+++ b/Source/Pulumock/Extensions/RegisteredOutputsExtensions.cs
@@ -5,23 +5,23 @@ namespace Pulumock.Extensions;
 /// <summary>
 /// Provides extension methods for retrieving strongly-typed values from Pulumi stack outputs.
 /// </summary>
-public static class StackOutputExtensions
+public static class RegisteredOutputsExtensions
 {
     /// <summary>
-    /// Retrieves a required output value from the stack outputs by key.
+    /// Retrieves a required output value from the registered outputs by key.
     /// Supports both direct values and <see cref="Output{T}"/>-wrapped values.
     /// Throws if the key is missing or the value type is invalid.
     /// </summary>
     /// <typeparam name="T">The expected output value type.</typeparam>
-    /// <param name="stackOutputs">The stack outputs dictionary.</param>
+    /// <param name="registeredOutputs">The registered outputs dictionary.</param>
     /// <param name="key">The key to retrieve from the outputs.</param>
     /// <returns>The resolved output value.</returns>
     /// <exception cref="InvalidOperationException">
     /// Thrown if the key is missing or the value cannot be cast to <typeparamref name="T"/> or <see cref="Output{T}"/>.
     /// </exception>
-    public static async Task<T> RequireValueAsync<T>(this IDictionary<string, object?> stackOutputs, string key)
+    public static async Task<T> RequireValueAsync<T>(this IDictionary<string, object?> registeredOutputs, string key)
     {
-        if (!stackOutputs.TryGetValue(key, out object? output) || output is null)
+        if (!registeredOutputs.TryGetValue(key, out object? output) || output is null)
         {
             throw new InvalidOperationException($"Output '{key}' was not found.");
         }
@@ -36,16 +36,16 @@ public static class StackOutputExtensions
     }
     
     /// <summary>
-    /// Attempts to retrieve an output value from the stack outputs by key.
+    /// Attempts to retrieve an output value from the registered outputs by key.
     /// Supports both direct values and <see cref="Output{T}"/>-wrapped values.
     /// </summary>
     /// <typeparam name="T">The expected output value type.</typeparam>
-    /// <param name="stackOutputs">The stack outputs dictionary.</param>
+    /// <param name="registeredOutputs">The registered outputs dictionary.</param>
     /// <param name="key">The key to retrieve from the outputs.</param>
     /// <returns>The resolved output value, or <c>default</c> if not found or mismatched type.</returns>
-    public static async Task<T?> GetValueAsync<T>(this IDictionary<string, object?> stackOutputs, string key)
+    public static async Task<T?> GetValueAsync<T>(this IDictionary<string, object?> registeredOutputs, string key)
     {
-        if (!stackOutputs.TryGetValue(key, out object? output) || output is null)
+        if (!registeredOutputs.TryGetValue(key, out object? output) || output is null)
         {
             throw new InvalidOperationException($"Output '{key}' was not found.");
         }

--- a/Source/Pulumock/TestFixtures/Fixture.cs
+++ b/Source/Pulumock/TestFixtures/Fixture.cs
@@ -14,7 +14,7 @@ namespace Pulumock.TestFixtures;
 /// <param name="StackOutputs">
 /// The outputs exposed by the Pulumi stack under test.
 /// </param>
-/// <param name="EnrichedStackResources">
+/// <param name="EnrichedResources">
 /// Enriched metadata for created resources, including their logical names and raw input arguments.
 /// </param>
 /// <param name="EnrichedStackCalls">
@@ -22,5 +22,5 @@ namespace Pulumock.TestFixtures;
 /// </param>
 public record Fixture(ImmutableArray<Resource> Resources, 
     ImmutableDictionary<string, object?> StackOutputs, 
-    ImmutableList<EnrichedResource> EnrichedStackResources,
+    ImmutableList<EnrichedResource> EnrichedResources,
     ImmutableList<EnrichedCall> EnrichedStackCalls);

--- a/Source/Pulumock/TestFixtures/Fixture.cs
+++ b/Source/Pulumock/TestFixtures/Fixture.cs
@@ -17,10 +17,10 @@ namespace Pulumock.TestFixtures;
 /// <param name="EnrichedResources">
 /// Enriched metadata for created resources, including their logical names and raw input arguments.
 /// </param>
-/// <param name="EnrichedStackCalls">
+/// <param name="EnrichedCalls">
 /// Enriched metadata for all provider function calls made by the stack, including tokens, inputs, and mocked outputs.
 /// </param>
 public record Fixture(ImmutableArray<Resource> Resources, 
     ImmutableDictionary<string, object?> StackOutputs, 
     ImmutableList<EnrichedResource> EnrichedResources,
-    ImmutableList<EnrichedCall> EnrichedStackCalls);
+    ImmutableList<EnrichedCall> EnrichedCalls);

--- a/Source/Pulumock/TestFixtures/Fixture.cs
+++ b/Source/Pulumock/TestFixtures/Fixture.cs
@@ -11,7 +11,7 @@ namespace Pulumock.TestFixtures;
 /// <param name="Resources">
 /// The Pulumi resources created during the test run, including both component and custom resources.
 /// </param>
-/// <param name="StackOutputs">
+/// <param name="RegisteredOutputs">
 /// The outputs exposed by the Pulumi stack under test.
 /// </param>
 /// <param name="EnrichedResources">
@@ -21,6 +21,6 @@ namespace Pulumock.TestFixtures;
 /// Enriched metadata for all provider function calls made by the stack, including tokens, inputs, and mocked outputs.
 /// </param>
 public record Fixture(ImmutableArray<Resource> Resources, 
-    ImmutableDictionary<string, object?> StackOutputs, 
+    ImmutableDictionary<string, object?> RegisteredOutputs, 
     ImmutableList<EnrichedResource> EnrichedResources,
     ImmutableList<EnrichedCall> EnrichedCalls);

--- a/Source/Pulumock/TestFixtures/Fixture.cs
+++ b/Source/Pulumock/TestFixtures/Fixture.cs
@@ -8,7 +8,7 @@ namespace Pulumock.TestFixtures;
 /// Represents the result of a Pulumock test execution, containing all captured resources,
 /// stack outputs, and enriched test metadata for inspection and assertions.
 /// </summary>
-/// <param name="StackResources">
+/// <param name="Resources">
 /// The Pulumi resources created during the test run, including both component and custom resources.
 /// </param>
 /// <param name="StackOutputs">
@@ -20,7 +20,7 @@ namespace Pulumock.TestFixtures;
 /// <param name="EnrichedStackCalls">
 /// Enriched metadata for all provider function calls made by the stack, including tokens, inputs, and mocked outputs.
 /// </param>
-public record Fixture(ImmutableArray<Resource> StackResources, 
+public record Fixture(ImmutableArray<Resource> Resources, 
     ImmutableDictionary<string, object?> StackOutputs, 
     ImmutableList<EnrichedResource> EnrichedStackResources,
     ImmutableList<EnrichedCall> EnrichedStackCalls);

--- a/Source/Pulumock/TestFixtures/FixtureBuilder.cs
+++ b/Source/Pulumock/TestFixtures/FixtureBuilder.cs
@@ -152,12 +152,12 @@ public class FixtureBuilder
 
         var mocks = new Mocks.Mocks(_mockResources.ToImmutableDictionary(), _mockCalls.ToImmutableDictionary());
         
-        (ImmutableArray<Resource> stackResources, IDictionary<string, object?> stackOutputs) = await Deployment.TestAsync(
+        (ImmutableArray<Resource> resources, IDictionary<string, object?> registeredOutputs) = await Deployment.TestAsync(
             mocks,
             testOptions ?? new TestOptions { IsPreview = false, StackName = "dev" },
             async () => await createResourcesFunc());
 
-        return new Fixture(stackResources, stackOutputs.ToImmutableDictionary(), mocks.EnrichedResources, mocks.EnrichedCalls);
+        return new Fixture(resources, registeredOutputs.ToImmutableDictionary(), mocks.EnrichedResources, mocks.EnrichedCalls);
     }
     
     /// <summary>
@@ -173,11 +173,11 @@ public class FixtureBuilder
 
         var mocks = new Mocks.Mocks(_mockResources.ToImmutableDictionary(), _mockCalls.ToImmutableDictionary());
         
-        (ImmutableArray<Resource> stackResources, IDictionary<string, object?> stackOutputs) = await Deployment.TestAsync(
+        (ImmutableArray<Resource> resources, IDictionary<string, object?> registeredOutputs) = await Deployment.TestAsync(
             mocks,
             testOptions ?? new TestOptions { IsPreview = false, StackName = "dev" },
             createResourcesFunc);
 
-        return new Fixture(stackResources, stackOutputs.ToImmutableDictionary(), mocks.EnrichedResources, mocks.EnrichedCalls);
+        return new Fixture(resources, registeredOutputs.ToImmutableDictionary(), mocks.EnrichedResources, mocks.EnrichedCalls);
     }
 }


### PR DESCRIPTION
Rename Fixture properties to make it more generic for both Stack and ComponentResource tests

StackResources -> Resources
StackOutputs -> RegisteredOutputs
EnrichedStackResources -> EnrichedResources
EnrichedStackCalls -> EnrichedCalls